### PR TITLE
Preserve timezone information in datetimes for metrics

### DIFF
--- a/instrumental_agent/agent.py
+++ b/instrumental_agent/agent.py
@@ -8,6 +8,7 @@ import socket
 import ssl
 import time
 import datetime
+import calendar
 import re
 import string
 if sys.version_info[0] < 3:
@@ -24,7 +25,7 @@ def normalize_time(time_like):
     if isinstance(time_like, time.struct_time):
         time_like = time.mktime(time_like)
     if isinstance(time_like, datetime.datetime):
-        time_like = time.mktime(time_like.utctimetuple())
+        time_like = calendar.timegm(time_like.utctimetuple())
     if isinstance(time_like, datetime.timedelta):
         time_like = time_like.total_seconds()
     return int(time_like)

--- a/test/agent_tests.py
+++ b/test/agent_tests.py
@@ -38,7 +38,7 @@ def test_should_increment_with_datetime():
     assert(a.queue.qsize()) == 1
     expected_message = re.compile('.*(increment python.increment 1 %i 1).*' % expected_timestamp)
     match = expected_message.match(str(a.queue.queue))
-    assert match, "expected increment to be in queue, instead have {0}".format(a.queue.queue)
+    assert match, "expected {0} to be in queue, instead have {1}".format(expected_message.pattern, a.queue.queue)
 
 def test_should_increment_with_struct_time():
     a = Agent("56c08a1a5b25ed2425b6dce7700edae5", collector="localhost:8000", secure=False)
@@ -105,7 +105,7 @@ def test_should_send_notice_with_datetime():
     assert(a.queue.qsize()) == 1
     expected_message = re.compile('.*(notice %i 10 Python Agent Test Is Running).*' % expected_timestamp)
     match = expected_message.match(str(a.queue.queue))
-    assert match, "expected gauge to be in queue, instead have {0}".format(a.queue.queue)
+    assert match, "expected {0} to be in queue, instead have {1}".format(expected_message.pattern, a.queue.queue)
 
 def test_should_send_notice_with_integer_time_and_timedelta_duration():
     a = Agent("56c08a1a5b25ed2425b6dce7700edae5", collector="localhost:8000", secure=False)

--- a/test/agent_tests.py
+++ b/test/agent_tests.py
@@ -2,8 +2,8 @@ from instrumental_agent import Agent
 import re
 import timeit
 import time
-import time
 import datetime
+import calendar
 
 def test_should_increment():
     a = Agent("56c08a1a5b25ed2425b6dce7700edae5", collector="localhost:8000", secure=False)
@@ -32,10 +32,11 @@ def test_should_increment_with_time():
 
 def test_should_increment_with_datetime():
     a = Agent("56c08a1a5b25ed2425b6dce7700edae5", collector="localhost:8000", secure=False)
-    now = datetime.datetime.fromtimestamp(123)
+    now = datetime.datetime.utcnow()
+    expected_timestamp = calendar.timegm(now.utctimetuple())
     a.increment("python.increment", 1, now)
     assert(a.queue.qsize()) == 1
-    expected_message = re.compile('.*(increment python.increment 1 %i 1).*' % 123)
+    expected_message = re.compile('.*(increment python.increment 1 %i 1).*' % expected_timestamp)
     match = expected_message.match(str(a.queue.queue))
     assert match, "expected increment to be in queue, instead have {0}".format(a.queue.queue)
 
@@ -98,10 +99,11 @@ def test_should_send_notice_with_struct_time():
 
 def test_should_send_notice_with_datetime():
     a = Agent("56c08a1a5b25ed2425b6dce7700edae5", collector="localhost:8000", secure=False)
-    now = datetime.datetime.fromtimestamp(123)
+    now = datetime.datetime.utcnow()
+    expected_timestamp = calendar.timegm(now.utctimetuple())
     a.notice("Python Agent Test Is Running", now, 10)
     assert(a.queue.qsize()) == 1
-    expected_message = re.compile('.*(notice %i 10 Python Agent Test Is Running).*' % 123)
+    expected_message = re.compile('.*(notice %i 10 Python Agent Test Is Running).*' % expected_timestamp)
     match = expected_message.match(str(a.queue.queue))
     assert match, "expected gauge to be in queue, instead have {0}".format(a.queue.queue)
 


### PR DESCRIPTION
Use calendar.timegm to coerce datetime objects instead of time.mktime…, in order to preserve timezone data if it is present.

Fixes #9 
