### PR TITLE
Standardize the agent string a little better.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+* make handshake version string match pattern of other 1st-party agents
+
 ### 1.0.2 [June 6, 2016]
 * Fix time defaulting to agent initialize instead of call time
 * Send correct agent version in hello

--- a/instrumental_agent/agent.py
+++ b/instrumental_agent/agent.py
@@ -251,7 +251,7 @@ class Agent(object):
                     else:
                         self.socket.send(bytes(data, "ASCII"))
 
-                socket_send("hello python/instrumental_agent/%(version)s hostname %(hostname)s\n" % {"version": Agent.version, "hostname": Agent.hostname})
+                socket_send("hello version python/instrumental_agent/%(version)s hostname %(hostname)s\n" % {"version": Agent.version, "hostname": Agent.hostname})
                 socket_send("authenticate %s\n" % self.api_key)
 
                 data = b""

--- a/instrumental_agent/agent.py
+++ b/instrumental_agent/agent.py
@@ -251,7 +251,7 @@ class Agent(object):
                     else:
                         self.socket.send(bytes(data, "ASCII"))
 
-                socket_send("hello version=%s agent=python\n" % Agent.version)
+                socket_send("hello python/instrumental_agent/%(version)s hostname %(hostname)s\n" % {"version": Agent.version, "hostname": Agent.hostname})
                 socket_send("authenticate %s\n" % self.api_key)
 
                 data = b""


### PR DESCRIPTION
Make the python hello handshake include the agent string in the manner the other 1st-party agents do, and also include hostname

Fixes #10 
