### PR TITLE
Suppress warning when logging to a logger without a handler

### DIFF
--- a/instrumental_agent/agent.py
+++ b/instrumental_agent/agent.py
@@ -17,8 +17,6 @@ else:
     from queue import Queue, Full
 
 from threading import Thread
-from logging import NullHandler
-import pkg_resources
 
 
 def normalize_time(time_like):

--- a/instrumental_agent/agent.py
+++ b/instrumental_agent/agent.py
@@ -95,7 +95,7 @@ class Agent(object):
 
     def __init__(self, api_key, collector="collector.instrumentalapp.com:8001", enabled=True, secure=True, verify_cert=True, synchronous=False):
         self.logger = logging.getLogger(__name__)
-        self.logger..addHandler(NullHandler())
+        self.logger.addHandler(logging.NullHandler())
         self.logger.setLevel(logging.DEBUG)
         self.logger.debug("Initializing...")
 

--- a/instrumental_agent/agent.py
+++ b/instrumental_agent/agent.py
@@ -17,6 +17,7 @@ else:
     from queue import Queue, Full
 
 from threading import Thread
+from logging import NullHandler
 import pkg_resources
 
 
@@ -94,6 +95,7 @@ class Agent(object):
 
     def __init__(self, api_key, collector="collector.instrumentalapp.com:8001", enabled=True, secure=True, verify_cert=True, synchronous=False):
         self.logger = logging.getLogger(__name__)
+        self.logger..addHandler(NullHandler())
         self.logger.setLevel(logging.DEBUG)
         self.logger.debug("Initializing...")
 


### PR DESCRIPTION
This fixes a warning when there is no logging handler defined for any given logger.
Example:  `No handlers could be found for logger "instrumental_agent.agent"`

I am truly sorry for having missed that in https://github.com/Instrumental/instrumental_agent-python/pull/14